### PR TITLE
Update documentation of the lsd.norm function to account for passing an array of len(lsd)

### DIFF
--- a/specpolFlow/profileLSD.py
+++ b/specpolFlow/profileLSD.py
@@ -191,7 +191,7 @@ class LSD:
         Return a renormalized LSD profile. Divides the I, V, and Null 
         profiles, and their uncertainties, by a value.
         
-        :param normValue: the float value or array with dimension len(lsd) to renormalize (divide) the LSD profile by
+        :param normValue: the float value or array with dimension len(LSD) to renormalize (divide) the LSD profile by
         :rtype: LSD
         """
         new = LSD(self.vel, 


### PR DESCRIPTION
The LSD object norm function can accept an array of len(lsd), in addition to a single float value. 

The docstring has been updated to reflect this. 

The API rendering was tested locally:

<img width="930" alt="image" src="https://github.com/user-attachments/assets/e62d4592-255d-4190-b709-9abc6812af59" />

